### PR TITLE
Jbws 4075 jaxws tools maven plugin fails on jdk9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <artifactId>jaxws-tools-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
 
-  <version>1.2.1.Final</version>
+  <version>1.2.2-SNAPSHOT</version>
 
   <!-- Parent -->
   <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <log4j.version>1.2.14</log4j.version>
     <maven.project.version>2.2.1</maven.project.version>
     <maven.plugin.api.version>2.2.1</maven.plugin.api.version>
-    <maven.invoker.plugin.version>1.5</maven.invoker.plugin.version>
+    <maven.invoker.plugin.version>3.0.1</maven.invoker.plugin.version>
     <!-- For test -->
     <junit.version>4.7</junit.version>
     <maven.plugin.testing.harness.version>1.1</maven.plugin.testing.harness.version>
@@ -68,7 +68,6 @@
       <version>${maven.plugin.testing.harness.version}</version>
       <scope>test</scope>
     </dependency>
-    
   </dependencies>
 
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <artifactId>jaxws-tools-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
 
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.2.1.Final</version>
 
   <!-- Parent -->
   <parent>


### PR DESCRIPTION
This change does not affect successful use of this tool by 3rd parties.  The change enables the local tests to run successfully both with jdk8 and jdk9.