### PR TITLE
[JBWS-4155] MANIFEST.MF must contain URLs in Class-Path entry.

### DIFF
--- a/src/main/java/org/jboss/ws/plugins/tools/AbstractToolsMojo.java
+++ b/src/main/java/org/jboss/ws/plugins/tools/AbstractToolsMojo.java
@@ -201,7 +201,7 @@ abstract class AbstractToolsMojo extends AbstractMojo
       }
       List<File> pluginDeps = getRequiredPluginDependencyPaths();
       for (File f : pluginDeps) {
-          cp.append(f.getAbsolutePath());
+          cp.append(f.toURI().toURL().toExternalForm());
           cp.append(" ");
       }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4155

Fix for the regression introduced by https://github.com/jbossws/jaxws-tools-maven-plugin/commit/e166dab2b80f56990b965c25f8ba49e7ffd64bca
Java can't read plain Windows paths from MANIFEST.MF, the entries should be URLs instead, generated the same way as other class path entries few lines above.